### PR TITLE
Revert "Update capybara: 3.8.2 → 3.9.0 (minor)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     ast (2.4.0)
-    capybara (3.9.0)
+    capybara (3.8.2)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)


### PR DESCRIPTION
Reverts Mifrill/parsers#51